### PR TITLE
Also check for node that is down or unknown

### DIFF
--- a/check_kube_nodes.sh
+++ b/check_kube_nodes.sh
@@ -79,6 +79,7 @@ for NODE in ${NODES[*]}; do
 			"MemoryPressure-True") returnResult Critical;;
 			"DiskPressure-True") returnResult Critical;;
 			"Ready-False") returnResult Warning;;
+			"Ready-Unknown") returnResult Warning;;
 			# Note the API only checks these 4 conditions at present. Others can be added here.
 			*) returnResult OK;;
 		esac


### PR DESCRIPTION
Detects when a node is down or in an unknown state, including errors such as "Kubelet not posting status"